### PR TITLE
TICKET-02: Feature prepare cookie button to be first

### DIFF
--- a/app/assets/stylesheets/ovens.css.scss
+++ b/app/assets/stylesheets/ovens.css.scss
@@ -1,3 +1,11 @@
-// Place all the styles related to the ovens controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/
+@media only screen and (max-width: 768px) {   
+  .tiny { 
+    position: relative; 
+    top: 100px; 
+  } 
+  
+  .prepare { 
+    position: relative; 
+    bottom: 40px; 
+  }
+}

--- a/app/views/ovens/show.html.haml
+++ b/app/views/ovens/show.html.haml
@@ -9,7 +9,7 @@
       = button_to "Retrieve Cookie", empty_oven_path, class: 'button tiny'
   - else
     None
-  = link_to "Prepare Cookie", new_oven_cookies_path(@oven), class: 'button'
+  = link_to "Prepare Cookie", new_oven_cookies_path(@oven), class: 'button prepare'
 %br
 
 

--- a/app/views/ovens/show.html.haml
+++ b/app/views/ovens/show.html.haml
@@ -9,7 +9,7 @@
       = button_to "Retrieve Cookie", empty_oven_path, class: 'button tiny'
   - else
     None
-
+  = link_to "Prepare Cookie", new_oven_cookies_path(@oven), class: 'button'
 %br
 
-= link_to "Prepare Cookie", new_oven_cookies_path(@oven), class: 'button'
+


### PR DESCRIPTION
The strategy was to put both buttons inside the same div, and then we used an [@media querie](https://www.w3schools.com/css/css_rwd_mediaqueries.asp) to reverse the order of the buttons in mobile

We use max-width: 768px

![2021-01-25_18-19](https://user-images.githubusercontent.com/3281672/105769946-5940e100-5f3d-11eb-83a0-6c3f3fcb8f83.png)
![2021-01-25_18-30](https://user-images.githubusercontent.com/3281672/105769961-5e059500-5f3d-11eb-9c7f-f3ab986bf2c1.png)

